### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -320,7 +320,7 @@ class ZitiBrowzerRuntime {
     let self = zitiBrowzerRuntime;
   
     CookieInterceptor.write.use( function ( cookie ) {
-      cookie = cookie.replace('%25','%');
+      cookie = cookie.replace(/%25/g, '%');
       let name = cookie.substring(0, cookie.indexOf("="));
       let value = cookie.substring(cookie.indexOf("=") + 1);
       let cookie_value = value.substring(0, value.indexOf(";"));


### PR DESCRIPTION
Potential fix for [https://github.com/openziti/ziti-browzer-runtime/security/code-scanning/1](https://github.com/openziti/ziti-browzer-runtime/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of `%25` in the `cookie` string are replaced with `%`. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of `%25` in the string is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
